### PR TITLE
Handle new SMART-DS format

### DIFF
--- a/disco/sources/base.py
+++ b/disco/sources/base.py
@@ -161,6 +161,9 @@ class BaseOpenDssModel(BaseSourceDataModel, ABC):
             "solve",
             "batchedit fuse",
             "new energymeter",
+            "new monitor",
+            "export monitors",
+            "plot",
         )
         self._comment_out_leading_strings(workspace.master_file, strings_to_remove)
         if self.loadshape_directory is not None:

--- a/disco/sources/source_tree_1/source_tree_1_model_inputs.py
+++ b/disco/sources/source_tree_1/source_tree_1_model_inputs.py
@@ -312,7 +312,8 @@ class SourceTree1ModelInputs(JobInputsInterface):
     @staticmethod
     def _feeder_from_dirname(dirname):
         fields = dirname.split(SourceTree1ModelInputs.SUBSTATION_DELIMITER)
-        assert len(fields) == 2
+        if len(fields) != 2:
+            return None
         return fields[1]
 
     def _list_available_params(self, param):
@@ -336,9 +337,13 @@ class SourceTree1ModelInputs(JobInputsInterface):
 
     @handle_file_not_found
     def _list_feeders(self, substation):
+        feeders = []
         feeder_path = os.path.join(self._base, substation)
-        return [self._feeder_from_dirname(x) for x in
-                self._get_items_from_directory(feeder_path)]
+        for item in self._get_items_from_directory(feeder_path):
+            feeder = self._feeder_from_dirname(item)
+            if feeder is not None:
+                feeders.append(feeder)
+        return feeders
 
     @handle_file_not_found
     def _list_placements(self, substation, feeder):


### PR DESCRIPTION
1. Accounts for the fact that the substation directory now contains non-feeder directories.
2. Comments-out OpenDSS items we don't want.