### PR TITLE
Make transformed model directory portable

### DIFF
--- a/disco/sources/gem/open_dss_generator.py
+++ b/disco/sources/gem/open_dss_generator.py
@@ -202,7 +202,8 @@ class OpenDssGenerator(ModelInputDataInterface):
             logger.debug("Copied %s to %s", path, target_path)
 
             src_dir = os.path.abspath(os.path.dirname(path))
-            OpenDssGenerator.fix_data_file_references(src_dir, target_path)
+            # TODO: add support for copying data files if we use this source model again.
+            OpenDssGenerator.make_data_file_references_absolute(src_dir, target_path)
 
     @staticmethod
     def _copy_upgrade_files(feeder, dst):
@@ -219,7 +220,7 @@ class OpenDssGenerator(ModelInputDataInterface):
             logger.debug("Copied %s to %s", src_file, dst_file)
 
     @staticmethod
-    def fix_data_file_references(src_dir, filename):
+    def make_data_file_references_absolute(src_dir, filename):
         """Change the path to any data file referenced in a .dss file to its
         absolute path."""
         # Example line:

--- a/docs/source/pipelines.rst
+++ b/docs/source/pipelines.rst
@@ -53,8 +53,6 @@ Create preconfigured models:
 
     $ disco transform-model tests/data/smart-ds/substations snapshot -o snapshot-feeder-models
 
-.. warning:: Don't change the directory name passed to the``-o`` option after creation. The name is used inside generated files.
-
 Then, use ``--preconfigured`` flag to indicate the input models ``snapshot-feeder-models`` are preconfigured.
 
 .. code-block:: bash

--- a/docs/source/transform-models.rst
+++ b/docs/source/transform-models.rst
@@ -54,6 +54,21 @@ in *format.toml*.
         disco transform-model tests/data/smart-ds/substations/ upgrade --help
 
 
+Load Shape Data files
+---------------------
+By default DISCO replaces relative paths to load shape data files with absolute
+paths and does not copy them. This reduces time and consumed storage space.
+However, it also makes the directory non-portable to other systems.
+
+If you want to create a portable directory with copies of these files, add
+this flag to the command:
+
+.. code-block:: bash
+
+   $ disco transform-model tests/data/smart-ds/substations time-series -c
+   $ disco transform-model tests/data/smart-ds/substations time-series --copy-load-shape-data-files
+
+
 DISCO Model in Depth
 ====================
 

--- a/tests/integration/test_snapshot.py
+++ b/tests/integration/test_snapshot.py
@@ -20,7 +20,7 @@ DISCO_PATH = disco.__path__[0]
 def test_snapshot_basic(cleanup):
     base = os.path.join(DISCO_PATH, "extensions", "pydss_simulation")
     config_file = CONFIG_FILE
-    transform_cmd = f"{TRANSFORM_MODEL} tests/data/smart-ds/substations snapshot -F -o {MODELS_DIR}"
+    transform_cmd = f"{TRANSFORM_MODEL} tests/data/smart-ds/substations snapshot -c -F -o {MODELS_DIR}"
     config_cmd = f"{CONFIG_JOBS} snapshot {MODELS_DIR} -c {CONFIG_FILE}"
     submit_cmd = f"{SUBMIT_JOBS} {config_file} -o {OUTPUT}"
 

--- a/tests/integration/test_time_series.py
+++ b/tests/integration/test_time_series.py
@@ -43,7 +43,7 @@ def test_time_series_basic(cleanup):
 
 def test_time_series_at_substation(cleanup):
     num_jobs = 18
-    transform_cmd = f"{TRANSFORM_MODEL} tests/data/smart-ds/substations time-series -F -o {MODELS_DIR} --hierarchy=substation"
+    transform_cmd = f"{TRANSFORM_MODEL} tests/data/smart-ds/substations time-series -c -F -o {MODELS_DIR} --hierarchy=substation"
     config_cmd = f"{CONFIG_JOBS} time-series {MODELS_DIR} -c {CONFIG_FILE}"
     submit_cmd = f"{SUBMIT_JOBS} {CONFIG_FILE} --output={OUTPUT}"
 
@@ -101,7 +101,7 @@ def test_time_series_impact_analysis(cleanup):
 
 def test_time_series_hosting_capacity(cleanup):
     num_jobs = 18
-    transform_cmd = f"{TRANSFORM_MODEL} tests/data/smart-ds/substations time-series -F -o {MODELS_DIR}"
+    transform_cmd = f"{TRANSFORM_MODEL} tests/data/smart-ds/substations time-series -c -F -o {MODELS_DIR}"
     config_cmd = f"{CONFIG_JOBS} time-series {MODELS_DIR} -c {CONFIG_FILE}"
     submit_cmd = f"{SUBMIT_JOBS} {CONFIG_FILE} --output={OUTPUT} -p 1"
 

--- a/tests/integration/test_transform_model.py
+++ b/tests/integration/test_transform_model.py
@@ -1,0 +1,20 @@
+"""Tests local execution of a snapshot simulation."""
+
+from pathlib import Path
+
+from jade.utils.subprocess_manager import check_run_command
+from tests.common import *
+
+
+def test_transform_no_copy_load_shape_data(cleanup):
+    transform_cmd = f"{TRANSFORM_MODEL} tests/data/smart-ds/substations time-series -F -o {MODELS_DIR}"
+    check_run_command(transform_cmd) == 0
+    load_shape_data_files = list(Path(MODELS_DIR).rglob("*.csv"))
+    assert not load_shape_data_files
+
+
+def test_transform_copy_load_shape_data(cleanup):
+    transform_cmd = f"{TRANSFORM_MODEL} tests/data/smart-ds/substations time-series -F -o {MODELS_DIR} -c"
+    check_run_command(transform_cmd) == 0
+    load_shape_data_files = list(Path(MODELS_DIR).rglob("*.csv"))
+    assert load_shape_data_files

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -50,7 +50,7 @@ def test_upgrade_cost_analysis(cleanup):
     submit_cmd = f"{SUBMIT_JOBS} {CONFIG_FILE} -o {OUTPUT}"
     assert run_command(submit_cmd) == 0
 
-    # verigy results
+    # verify results
     result_summary = ResultsSummary(OUTPUT)
     results = result_summary.list_results()
     assert len(results) == 16


### PR DESCRIPTION
This PR enables full portability of DISCO transformed models to different systems. For source data types that conform to the SMART-DS data layout you can now specify a `--copy-load-shape-data-files` flag that will copy all load shape data files to the target directory. It will only copy data files that match the input filters (i.e., you can specify a single feeder/placement/sample and only get those load shapes).

This PR also changes behavior to allow you to rename the transformed directory - all generated file paths are now relative.

@ann-sherin It's become quite annoying that the upgrade tests don't work. They fail with convergence errors. This makes it onerous to make these sorts of changes. Can you look into why these fail? Something must be wrong with the input test data.