### PR TITLE
Add pv config customer type

### DIFF
--- a/disco/sources/source_tree_1/pv_deployments.py
+++ b/disco/sources/source_tree_1/pv_deployments.py
@@ -816,7 +816,7 @@ class PVScenarioGeneratorBase(abc.ABC):
                 elif "res_" in shape_name:
                     customer_type = "residential"
                 else:
-                    raise ValueError("No valid customer type detected.")
+                    customer_type = None
                 customer_types[bus_name] = customer_type
         return customer_types
 


### PR DESCRIPTION
To solve issue - https://agile.nrel.gov/browse/DISCO-331

result example

```json
{
      "name": "small_p10ulv19205_1_2_3_pv",
      "pydss_controller": {
        "controller_type": "PvController",
        "name": "volt-var"
      },
      "pv_profile": "53404_37.74_-122.57_2018",
      "customer_type": "residential"
},
{
      "name": "small_p10ulv1973_1_2_3_pv",
      "pydss_controller": {
        "controller_type": "PvController",
        "name": "volt-var"
      },
      "pv_profile": "60876_37.78_-122.31_2018",
      "customer_type": "commercial"
}
```