### PR TITLE
accounting for feeders without transformers

### DIFF
--- a/disco/postprocess/hosting_capacity.py
+++ b/disco/postprocess/hosting_capacity.py
@@ -167,6 +167,12 @@ def compute_hc_per_metric_class(
         metric_df = metric_df[metric_df.node_types == node_types[0]]
 
     queries = build_queries(metric_df.columns, thresholds, metric_class, on=on)
+
+    if metric_class == "thermal":
+        if (metric_df.transformer_instantaneous_threshold.isna().any() or 
+            metric_df.transformer_instantaneous_threshold.isnull().any()):
+            queries = [q for q in queries if 'transformer' not in q]
+
     query_phrase = " & ".join(queries)
 
     metric_df.penetration_level = metric_df.penetration_level.astype("float")

--- a/disco/postprocess/hosting_capacity.py
+++ b/disco/postprocess/hosting_capacity.py
@@ -176,7 +176,6 @@ def compute_hc_per_metric_class(
         )
 
     if metric_class == "thermal":
-        breakpoint()
         if (metric_df.transformer_instantaneous_threshold.isna().any() or 
             metric_df.transformer_instantaneous_threshold.isnull().any()):
             queries = [q for q in queries if 'transformer' not in q]

--- a/disco/postprocess/hosting_capacity.py
+++ b/disco/postprocess/hosting_capacity.py
@@ -198,19 +198,16 @@ def get_hosting_capacity(meta_df, metric_df, query_phrase, metric_class, hc_summ
     recommended_cba_sample: the sample with the highest violation frequency, recommended for further cost benefit analysis or upgrade
 
     """
-    pass_df = metric_df.query(query_phrase)
-    fail_df = metric_df.query(f"~({query_phrase})")
-    feeders = set(metric_df.feeder)
+    
     cba_samples = set(metric_df['sample'])
     violation_starting_penetration = 0
     violation_frequency_by_sample = {}
 
-    for feeder in feeders:
+    for feeder, temp_df in metric_df.groupby(by="feeder"):
         if not feeder in hc_summary.keys():
             hc_summary[feeder] = dict()
-        temp_pass = pass_df[pass_df.feeder == feeder]
-        temp_fail = fail_df[fail_df.feeder == feeder]
-        temp_df = metric_df[metric_df.feeder == feeder]
+        temp_pass = temp_df.query(query_phrase)
+        temp_fail = temp_df.query(f"~({query_phrase})")
         violation_frequency_by_sample = {d:len(temp_fail.query('sample == @d'))/len(temp_df.query('sample == @d')) for d in temp_df['sample'].unique()}
         recommended_cba_sample = max(violation_frequency_by_sample, key=violation_frequency_by_sample.get)
         fail_penetration_levels = set(temp_fail.penetration_level.values)

--- a/disco/postprocess/hosting_capacity.py
+++ b/disco/postprocess/hosting_capacity.py
@@ -167,12 +167,6 @@ def compute_hc_per_metric_class(
         metric_df = metric_df[metric_df.node_types == node_types[0]]
 
     queries = build_queries(metric_df.columns, thresholds, metric_class, on=on)
-
-    if metric_class == "thermal":
-        if (metric_df.transformer_instantaneous_threshold.isna().any() or 
-            metric_df.transformer_instantaneous_threshold.isnull().any()):
-            queries = [q for q in queries if 'transformer' not in q]
-
     query_phrase = " & ".join(queries)
 
     metric_df.penetration_level = metric_df.penetration_level.astype("float")
@@ -180,6 +174,19 @@ def compute_hc_per_metric_class(
         hc_summary = get_hosting_capacity(
             meta_df, metric_df, query_phrase, metric_class, hc_summary
         )
+
+    if metric_class == "thermal":
+        breakpoint()
+        if (metric_df.transformer_instantaneous_threshold.isna().any() or 
+            metric_df.transformer_instantaneous_threshold.isnull().any()):
+            queries = [q for q in queries if 'transformer' not in q]
+            noxfmr_metric_df = metric_df.loc[metric_df.transformer_instantaneous_threshold.isna(), :]
+            noxfmr_query_phrase = " & ".join(queries)
+            if noxfmr_query_phrase:
+                hc_summary = get_hosting_capacity(
+                    meta_df, noxfmr_metric_df, noxfmr_query_phrase, metric_class, hc_summary
+                )
+    
     return hc_summary, query_phrase
 
 


### PR DESCRIPTION
This change in the hosting capacity computation accommodates feeders that may not have distribution transformers, instead of throwing them away systematically. 