### PR TITLE
Set pipeline params to run more efficiently

### DIFF
--- a/disco/pipelines/template/snapshot-default-template.toml
+++ b/disco/pipelines/template/snapshot-default-template.toml
@@ -40,12 +40,12 @@ verbose = false
 
 [postprocess.submitter-params]
 hpc_config = "hpc_config.toml"
-per_node_batch_size = 1
+per_node_batch_size = 32
 poll_interval = 60
 resource_monitor_interval = 0
 num_processes = "null"
 generate_reports = true
-try_add_blocked_jobs = false
+try_add_blocked_jobs = true
 verbose = false
 node_setup_script = "null"
 node_shutdown_script = "null"

--- a/disco/pipelines/template/time-series-default-template.toml
+++ b/disco/pipelines/template/time-series-default-template.toml
@@ -65,12 +65,12 @@ verbose = false
 
 [postprocess.submitter-params]
 hpc_config = "hpc_config.toml"
-per_node_batch_size = 1
+per_node_batch_size = 32
 poll_interval = 60
 resource_monitor_interval = 0
 num_processes = "null"
 generate_reports = true
-try_add_blocked_jobs = false
+try_add_blocked_jobs = true
 verbose = false
 node_setup_script = "null"
 node_shutdown_script = "null"

--- a/disco/pipelines/template/upgrade-default-template.toml
+++ b/disco/pipelines/template/upgrade-default-template.toml
@@ -36,12 +36,12 @@ verbose = false
 
 [postprocess.submitter-params]
 hpc_config = "hpc_config.toml"
-per_node_batch_size = 1
+per_node_batch_size = 32
 poll_interval = 60
 resource_monitor_interval = 0
 num_processes = "null"
 generate_reports = true
-try_add_blocked_jobs = false
+try_add_blocked_jobs = true
 verbose = false
 node_setup_script = "null"
 node_shutdown_script = "null"


### PR DESCRIPTION
This will let all post-processing jobs run on a single node allocation
instead of several.